### PR TITLE
[fix] requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dashscope
 datasets>=2.8.0
 ipython
-langchain
+langchain<=0.0.292
 modelscope>=1.7.0
 moviepy
 ms-swift


### PR DESCRIPTION
langchain remove base class of embedding in v0.0.293, so temporarily set langchain version <=0.0.292
![image](https://github.com/modelscope/modelscope-agent/assets/55917203/b169e64a-ba9f-4502-9064-79850cce7d0e)
![image](https://github.com/modelscope/modelscope-agent/assets/55917203/926acb28-b078-4b6e-8909-a7b538908cbe)
