### PR TITLE
adjust create configure and fix knowledge file path error for published agent

### DIFF
--- a/apps/agentfabric/app.py
+++ b/apps/agentfabric/app.py
@@ -152,6 +152,19 @@ with demo:
     with gr.Row():
         with gr.Column():
             with gr.Tabs() as tabs:
+                with gr.TabItem('Create', id=0):
+                    with gr.Column():
+                        # "Create" 标签页的 Chatbot 组件
+                        start_text = '欢迎使用agent创建助手。我可以帮助您创建一个定制agent。'\
+                            '您希望您的agent主要用于什么领域或任务？比如，您可以说，我想做一个RPG游戏agent'
+                        create_chatbot = gr.Chatbot(
+                            label='Create Chatbot', value=[[None, start_text]])
+                        create_chat_input = gr.Textbox(
+                            label='Message',
+                            placeholder='Type a message here...')
+                        create_send_button = gr.Button(
+                            'Send (Agent Loading...)', interactive=False)
+
                 configure_tab = gr.Tab('Configure', id=1)
                 with configure_tab:
                     with gr.Column():
@@ -220,19 +233,6 @@ with demo:
                                 placeholder='Enter privacy policy URL')
 
                         configure_button = gr.Button('Update Configuration')
-
-                with gr.TabItem('Create', id=0):
-                    with gr.Column():
-                        # "Create" 标签页的 Chatbot 组件
-                        start_text = '欢迎使用agent创建助手。我可以帮助您创建一个定制agent。'\
-                            '您希望您的agent主要用于什么领域或任务？比如，您可以说，我想做一个RPG游戏agent'
-                        create_chatbot = gr.Chatbot(
-                            label='Create Chatbot', value=[[None, start_text]])
-                        create_chat_input = gr.Textbox(
-                            label='Message',
-                            placeholder='Type a message here...')
-                        create_send_button = gr.Button(
-                            'Send (Agent Loading...)', interactive=False)
 
         with gr.Column():
             # Preview

--- a/apps/agentfabric/config/model_config.json
+++ b/apps/agentfabric/config/model_config.json
@@ -23,14 +23,6 @@
             "top_p": 0.8
         }
     },
-    "gpt-3.5-turbo": {
-        "type": "openai",
-        "model": "gpt-3.5-turbo"
-    },
-    "gpt-4": {
-        "type": "openai",
-        "model": "gpt-4"
-    },
     "qwen-7b": {
         "type": "modelscope",
         "model_id": "qwen/Qwen-7B-Chat",
@@ -41,7 +33,7 @@
             "max_length": 2000
         }
     },
-    "qwen-7b-dashscope": {
+    "qwen-7b-api": {
         "type": "dashscope",
         "model": "qwen-7b-chat",
         "generate_cfg": {
@@ -60,7 +52,7 @@
             "max_length": 2000
         }
     },
-    "qwen-14b-dashscope": {
+    "qwen-14b-api": {
         "type": "dashscope",
         "model": "qwen-14b-chat",
         "generate_cfg": {
@@ -69,7 +61,7 @@
             "debug": false
         }
     },
-    "qwen-72b": {
+    "qwen-72b-api": {
         "type": "dashscope",
         "model": "qwen-72b-chat",
         "generate_cfg": {

--- a/apps/agentfabric/publish_util.py
+++ b/apps/agentfabric/publish_util.py
@@ -5,6 +5,8 @@ from configparser import ConfigParser
 
 import oss2
 
+from modelscope.utils.config import Config
+
 
 def upload_to_oss(bucket, local_file_path, oss_file_path):
     # 上传文件到阿里云OSS
@@ -49,13 +51,19 @@ def prepare_agent_zip(agent_name, uuid_str, state):
 
     # 创建新目录
     if os.path.exists(new_directory):
-        os.removedirs(new_directory)
+        shutil.rmtree(new_directory)
         os.makedirs(new_directory)
 
     # 复制config下的uuid_str目录到new_directory下并改名为local_user
     uuid_str_path = f'{src_dir}/config/{uuid_str}'  # 指向uuid_str目录的路径
     local_user_path = f'{new_directory}/config/local_user'  # 新的目录路径
     shutil.copytree(uuid_str_path, local_user_path, dirs_exist_ok=True)
+
+    target_conf = os.path.join(local_user_path, 'builder_config.json')
+    builder_cfg = Config.from_file(target_conf)
+    builder_cfg.knowledge = [
+        f.replace(uuid_str, 'local_user') for f in builder_cfg.knowledge
+    ]
 
     # 复制config目录下所有.json文件到new_directory/config
     config_path = f'{src_dir}/config'


### PR DESCRIPTION
1. remove openai  gpt3.5 and gpt4 temperaily
2. rename qwen dashscope api to qwen-api
3. fix knowledge file path error for published agent

![image](https://github.com/modelscope/modelscope-agent/assets/4771825/9b6f9863-78e2-4c65-835d-d138da008fb7)
