### PR TITLE
Update modelscope_llm.py

### DIFF
--- a/modelscope_agent/llm/modelscope_llm.py
+++ b/modelscope_agent/llm/modelscope_llm.py
@@ -18,9 +18,10 @@ class ModelScopeLLM(LLM):
         model_id = self.cfg.get('model_id', '')
         self.model_id = model_id
         model_revision = self.cfg.get('model_revision', None)
+        cache_dir = self.cfg.get('cache_dir', None)
 
         if not os.path.exists(model_id):
-            model_dir = snapshot_download(model_id, model_revision)
+            model_dir = snapshot_download(model_id, model_revision, cache_dir = cache_dir)
         else:
             model_dir = model_id
         self.model_dir = model_dir


### PR DESCRIPTION
Add the option of 'cache_dir' to the config file to change the model save address.

通过cfg传参数的方式来设置cache_dir，指定模型的保存路径。