### PR TITLE
add missing files for font

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include modelscope_agent/tools/code_interpreter_utils *.ttf


### PR DESCRIPTION
fix code interpreter error when installed from whl,  the error is as follows

```bash
[2023-12-10 19:37:32] To disable this warning, you can either:
[2023-12-10 19:37:32]     - Avoid using `tokenizers` before the fork if possible
[2023-12-10 19:37:32]     - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
[2023-12-10 19:37:32] INFO: kernel process's PID = 7943
[2023-12-10 19:37:36] ---------------------------------------------------------------------------
[2023-12-10 19:37:36] FileNotFoundError                         Traceback (most recent call last)
[2023-12-10 19:37:36] Cell In[1], line 50
[2023-12-10 19:37:36]      47 sns.set_theme()
[2023-12-10 19:37:36]      49 _m6_font_prop = FontProperties(fname='/opt/conda/lib/python3.8/site-packages/modelscope_agent/tools/code_interpreter_utils/AlibabaPuHuiTi-3-45-Light.ttf')
[2023-12-10 19:37:36] ---> 50 plt.rcParams['font.family'] = _m6_font_prop.get_name()
[2023-12-10 19:37:36] 
[2023-12-10 19:37:36] File /opt/conda/lib/python3.8/site-packages/matplotlib/font_manager.py:737, in FontProperties.get_name(self)
[2023-12-10 19:37:36]     733 def get_name(self):
[2023-12-10 19:37:36]     734     """
[2023-12-10 19:37:36]     735     Return the name of the font that best matches the font properties.
[2023-12-10 19:37:36]     736     """
[2023-12-10 19:37:36] --> 737     return get_font(findfont(self)).family_name
[2023-12-10 19:37:36] 
[2023-12-10 19:37:36] File /opt/conda/lib/python3.8/site-packages/matplotlib/font_manager.py:1424, in get_font(filename, hinting_factor)
[2023-12-10 19:37:36]    1422     hinting_factor = rcParams['text.hinting_factor']
[2023-12-10 19:37:36]    1423 # also key on the thread ID to prevent segfaults with multi-threading
[2023-12-10 19:37:36] -> 1424 return _get_font(filename, hinting_factor,
[2023-12-10 19:37:36]    1425                  _kerning_factor=rcParams['text.kerning_factor'],
[2023-12-10 19:37:36]    1426                  thread_id=threading.get_ident())
[2023-12-10 19:37:36] 
[2023-12-10 19:37:36] File /opt/conda/lib/python3.8/site-packages/matplotlib/font_manager.py:1405, in _get_font(filename, hinting_factor, _kerning_factor, thread_id)
[2023-12-10 19:37:36]    1403 @lru_cache(64)
[2023-12-10 19:37:36]    1404 def _get_font(filename, hinting_factor, *, _kerning_factor, thread_id):
[2023-12-10 19:37:36] -> 1405     return ft2font.FT2Font(
[2023-12-10 19:37:36]    1406         filename, hinting_factor, _kerning_factor=_kerning_factor)
[2023-12-10 19:37:36] 
[2023-12-10 19:37:36] FileNotFoundError: [Errno 2] No such file or directory: '/opt/conda/lib/python3.8/site-packages/modelscope_agent/tools/code_interpreter_utils/AlibabaPuHuiTi-3-45-Light.ttf'
```