### PR TITLE
fix mapping

### DIFF
--- a/modelscope_agent/action_parser_factory.py
+++ b/modelscope_agent/action_parser_factory.py
@@ -34,7 +34,7 @@ class ActionParserFactory:
             language = kwargs.pop('language', 'en')
             action_parser = cls._get_model_default_type(model, language, uuid)
             if action_parser:
-                return cls._string_to_obj(action_parser, **kwargs)
+                return action_parser(**kwargs)
 
         return cls._get_action_parser_by_agent_type(agent_type, **kwargs)
 

--- a/modelscope_agent/constant.py
+++ b/modelscope_agent/constant.py
@@ -1,28 +1,34 @@
+from modelscope_agent.action_parser import (ChatGLMActionParser,
+                                            MRKLActionParser, MsActionParser,
+                                            OpenAiFunctionsActionParser)
+from modelscope_agent.prompt import (ChatGLMPromptGenerator, MessagesGenerator,
+                                     MrklPromptGenerator, MSPromptGenerator)
+
 DEFAULT_MODEL_CONFIG = {
     'qwen': {
         'en': {
-            'prompt_generator': 'MrklPromptGenerator',
-            'action_parser': 'MRKLActionParser'
+            'prompt_generator': MrklPromptGenerator,
+            'action_parser': MRKLActionParser
         },
         'zh': {
-            'prompt_generator': 'MrklPromptGenerator',
-            'action_parser': 'MRKLActionParser'
+            'prompt_generator': MrklPromptGenerator,
+            'action_parser': MRKLActionParser
         }
     },
     'qwen-plus': {
-        'prompt_generator': 'MessagesGenerator',
-        'action_parser': 'MRKLActionParser'
+        'prompt_generator': MessagesGenerator,
+        'action_parser': MRKLActionParser
     },
     'chatglm': {
-        'prompt_generator': 'ChatGLMPromptGenerator',
-        'action_parser': 'ChatGLMActionParser'
+        'prompt_generator': ChatGLMPromptGenerator,
+        'action_parser': ChatGLMActionParser
     },
     'gpt': {
-        'prompt_generator': 'MrklPromptGenerator',
-        'action_parser': 'MRKLActionParser'
+        'prompt_generator': MrklPromptGenerator,
+        'action_parser': MRKLActionParser
     },
     'openai': {
-        'prompt_generator': 'MrklPromptGenerator',
-        'action_parser': 'MRKLActionParser'
+        'prompt_generator': MrklPromptGenerator,
+        'action_parser': MRKLActionParser
     }
 }

--- a/modelscope_agent/prompt/prompt_factory.py
+++ b/modelscope_agent/prompt/prompt_factory.py
@@ -37,8 +37,7 @@ class PromptGeneratorFactory:
             prompt_generator = cls._get_model_default_type(
                 model, language, uuid)
             if prompt_generator:
-                return cls._string_to_obj(
-                    prompt_generator, llm=model, **kwargs)
+                return prompt_generator(llm=model, **kwargs)
 
         return cls._get_prompt_generator_by_agent_type(
             agent_type, llm=model, **kwargs)


### PR DESCRIPTION
将mapping的映射由 str: str 转为 str: cls。 原因：如果类名变换，后者能检查出来，前者不能