### PR TITLE
update agent _detect_tool compatible with openai api

### DIFF
--- a/modelscope_agent/agent.py
+++ b/modelscope_agent/agent.py
@@ -144,6 +144,12 @@ class Agent(ABC):
             func_call = message['function_call']
             func_name = func_call.get('name', '')
             func_args = func_call.get('arguments', '')
+        # Compatible with OpenAI API
+        if 'tool_calls' in message and message['tool_calls']:
+            func_call = message['tool_calls'][0]['function']
+            func_name = func_call.get('name', '')
+            func_args = func_call.get('arguments', '')
+
         text = message.get('content', '')
 
         return (func_name is not None), func_name, func_args, text


### PR DESCRIPTION
1. [functions_with_chat_models for openai api](https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models) 
<img width="869" alt="image" src="https://github.com/modelscope/modelscope-agent/assets/16071449/5fda2cb1-98ea-45ba-9e50-7975c023373f">
2. 在父类 Agent 中 _detect_tool 添加解析 openai 接口返回的 function name 和 argument 