### PR TITLE
ffmpeg download stuck, temporarily bypass

### DIFF
--- a/.dev_scripts/dockerci.sh
+++ b/.dev_scripts/dockerci.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # install dependencies for ci
-wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz
-tar xvf ffmpeg.tar.xz
+#wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz
+#tar xvf ffmpeg.tar.xz
 export export PATH=`pwd`:$PATH
 pip install torch
 export CODE_INTERPRETER_WORK_DIR=${GITHUB_WORKSPACE}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

##  The downloading url is timeout, should temporarily bypass

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
