### PR TITLE
add token counting logic (#341)

### DIFF
--- a/apps/agentfabric/app.py
+++ b/apps/agentfabric/app.py
@@ -432,7 +432,6 @@ with demo:
                 yield {
                     create_chatbot: chatbot,
                 }
-        # print(f'token count of builder agent: {builder_memory.get_token_count()}')
 
     create_chat_input.submit(
         create_send_message,
@@ -615,7 +614,6 @@ with demo:
                 msg = str(e)
             chatbot[-1][1] = msg
             yield {user_chatbot: chatbot}
-        # print(f'token count of user agent: {user_memory.get_token_count()}')
 
     preview_chat_input.submit(
         preview_send_message,

--- a/apps/agentfabric/app.py
+++ b/apps/agentfabric/app.py
@@ -432,6 +432,7 @@ with demo:
                 yield {
                     create_chatbot: chatbot,
                 }
+        # print(f'token count of builder agent: {builder_memory.get_token_count()}')
 
     create_chat_input.submit(
         create_send_message,
@@ -614,6 +615,7 @@ with demo:
                 msg = str(e)
             chatbot[-1][1] = msg
             yield {user_chatbot: chatbot}
+        # print(f'token count of user agent: {user_memory.get_token_count()}')
 
     preview_chat_input.submit(
         preview_send_message,

--- a/modelscope_agent/memory/base.py
+++ b/modelscope_agent/memory/base.py
@@ -9,7 +9,6 @@ from pydantic import ConfigDict
 
 class Memory(AgentAttr):
     path: str
-    accumulated_token_count: int = 0
     model_config = ConfigDict(extra='allow')
 
     def save_history(self):
@@ -62,15 +61,14 @@ class Memory(AgentAttr):
 
     def update_history(self, message: Union[Message, Iterable[Message]]):
         if isinstance(message, list):
-            self.accumulated_token_count += sum(
-                count_tokens(msg.content) for msg in message)
             self.history.extend(message)
         else:
-            self.accumulated_token_count += count_tokens(message.content)
             self.history.append(message)
 
-    def get_token_count(self) -> int:
-        return self.accumulated_token_count
+    def get_history_token_count(self) -> int:
+        history_token_count = sum(
+            count_tokens(message.content) for message in self.history)
+        return history_token_count
 
     def pop_history(self):
         return self.history.pop()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,7 +3,7 @@ from modelscope_agent.agents.role_play import RolePlay
 from modelscope_agent.llm import BaseChatModel
 from modelscope_agent.tools import TOOL_REGISTRY, BaseTool
 
-from .utils import MockTool
+from .ut_utils import MockTool
 
 
 class MockTool1(MockTool):

--- a/tests/ut_utils.py
+++ b/tests/ut_utils.py
@@ -1,0 +1,15 @@
+from modelscope_agent.tools import BaseTool
+
+
+class MockTool(BaseTool):
+    name: str = 'mock_tool'
+    description: str = 'description'
+    parameters: list = [{
+        'name': 'test',
+        'type': 'string',
+        'description': 'test variable',
+        'required': False
+    }]
+
+    def call(self, params: str, **kwargs):
+        return params

--- a/tests/utils/test_token_count.py
+++ b/tests/utils/test_token_count.py
@@ -23,10 +23,28 @@ def test_memory_with_retrieval_knowledge(temporary_storage):
         name=random_name,
         memory_path=temporary_storage,
     )
-    old_token_count = memory.get_token_count()
-    assert isinstance(old_token_count, int)
-    msg = Message(role='system', content='test token counting')
+    # 1. test get history token count
+    history_token_count_1 = memory.get_history_token_count()
+    assert isinstance(history_token_count_1, int)
+
+    # 2. test update history
+    msg = [
+        Message(role='system', content='test token counting'),
+        Message(role='user', content='test token counting'),
+    ]
     memory.update_history(msg)
-    new_token_count = memory.get_token_count()
-    assert isinstance(new_token_count, int)
-    assert new_token_count > old_token_count
+    history_token_count_2 = memory.get_history_token_count()
+    assert isinstance(history_token_count_2, int)
+    assert history_token_count_2 > history_token_count_1
+
+    # 3. test pop history
+    memory.pop_history()
+    history_token_count_3 = memory.get_history_token_count()
+    assert isinstance(history_token_count_3, int)
+    assert history_token_count_2 > history_token_count_3 > 0
+
+    # 4. test clear history
+    memory.clear_history()
+    history_token_count_4 = memory.get_history_token_count()
+    assert isinstance(history_token_count_4, int)
+    assert history_token_count_4 == 0

--- a/tests/utils/test_token_count.py
+++ b/tests/utils/test_token_count.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+from modelscope_agent.memory.memory_with_retrieval_knowledge import \
+    MemoryWithRetrievalKnowledge
+from modelscope_agent.schemas import Message
+
+current_file_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_file_dir)
+
+
+@pytest.fixture
+def temporary_storage(tmpdir):
+    # Use a temporary directory for testing storage
+    return str(tmpdir.mkdir('knowledge_vector_test'))
+
+
+def test_memory_with_retrieval_knowledge(temporary_storage):
+    random_name = 'test_memory_agent'
+
+    memory = MemoryWithRetrievalKnowledge(
+        storage_path=temporary_storage,
+        name=random_name,
+        memory_path=temporary_storage,
+    )
+    old_token_count = memory.get_token_count()
+    assert isinstance(old_token_count, int)
+    msg = Message(role='system', content='test token counting')
+    memory.update_history(msg)
+    new_token_count = memory.get_token_count()
+    assert isinstance(new_token_count, int)
+    assert new_token_count > old_token_count


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

在memory类中，增加了token counting的逻辑。token count会随着每一次的`memory.update_history`进行更新。增加了此feature后，可以在AgentFabric中灵活调用`memory.get_token_count`接口，获取token的消耗总量。

## Related issue number

fix #341

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [x] Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
