### PR TITLE
Pass parameters freely to scripts/run_assistant_server.sh

### DIFF
--- a/scripts/run_assistant_server.sh
+++ b/scripts/run_assistant_server.sh
@@ -55,7 +55,7 @@ if [ "$MODEL_DIR" != "" ]; then
     # Function to check if the first server is up
     check_first_server() {
         echo "Checking if Server 1 is up..."
-        for i in {1..10}; do # try up to 10 times
+        for i in {1..1000000000}; do
             curl -s http://localhost:8000 > /dev/null
             if [ $? -eq 0 ]; then
                 echo "Server 1 is up and running."

--- a/scripts/run_assistant_server.sh
+++ b/scripts/run_assistant_server.sh
@@ -46,7 +46,7 @@ export PYTHONPATH=$PYTHONPATH:modelscope_agent_servers
 if [ "$MODEL_DIR" != "" ]; then
     echo "Running vllm server, please make sure install vllm"
     # Start the first server in the background on port 8000
-    python -m vllm.entrypoints.openai.api_server --served-model-name $MODEL_NAME --model $MODEL_DIR --quantization gptq --kv-cache-dtype fp8_e5m2 --tensor-parallel-size 8  & SERVER_1_PID=$!
+    python -m vllm.entrypoints.openai.api_server --served-model-name $MODEL_NAME --model $MODEL_DIR  & SERVER_1_PID=$!
     export MODEL_SERVER=vllm-server
     export OPENAI_API_BASE=http://localhost:8000/v1
     echo "Model server: $MODEL_SERVER"
@@ -55,7 +55,7 @@ if [ "$MODEL_DIR" != "" ]; then
     # Function to check if the first server is up
     check_first_server() {
         echo "Checking if Server 1 is up..."
-        for i in {1..10000}; do
+        for i in {1..10}; do # try up to 10 times
             curl -s http://localhost:8000 > /dev/null
             if [ $? -eq 0 ]; then
                 echo "Server 1 is up and running."

--- a/scripts/run_assistant_server.sh
+++ b/scripts/run_assistant_server.sh
@@ -46,7 +46,7 @@ export PYTHONPATH=$PYTHONPATH:modelscope_agent_servers
 if [ "$MODEL_DIR" != "" ]; then
     echo "Running vllm server, please make sure install vllm"
     # Start the first server in the background on port 8000
-    python -m vllm.entrypoints.openai.api_server --served-model-name $MODEL_NAME --model $MODEL_DIR  & SERVER_1_PID=$!
+    python -m vllm.entrypoints.openai.api_server --served-model-name $MODEL_NAME --model $MODEL_DIR --quantization gptq --kv-cache-dtype fp8_e5m2 --tensor-parallel-size 8  & SERVER_1_PID=$!
     export MODEL_SERVER=vllm-server
     export OPENAI_API_BASE=http://localhost:8000/v1
     echo "Model server: $MODEL_SERVER"
@@ -55,7 +55,7 @@ if [ "$MODEL_DIR" != "" ]; then
     # Function to check if the first server is up
     check_first_server() {
         echo "Checking if Server 1 is up..."
-        for i in {1..10}; do # try up to 10 times
+        for i in {1..10000}; do
             curl -s http://localhost:8000 > /dev/null
             if [ $? -eq 0 ]; then
                 echo "Server 1 is up and running."

--- a/scripts/run_assistant_server.sh
+++ b/scripts/run_assistant_server.sh
@@ -9,6 +9,9 @@ MODEL_DIR=""
 MODEL_SERVER=""
 MODEL_NAME=""
 
+# Save all command line arguments
+ALL_ARGS="$@"
+
 # Loop through arguments and process them
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -38,7 +41,6 @@ echo "Model name: $MODEL_NAME"
 echo "Model directory: $MODEL_DIR"
 echo "Model server: $MODEL_SERVER"
 
-
 # running
 echo "Running fastapi assistant server at port 31512."
 export PYTHONPATH=$PYTHONPATH:modelscope_agent_servers
@@ -46,7 +48,7 @@ export PYTHONPATH=$PYTHONPATH:modelscope_agent_servers
 if [ "$MODEL_DIR" != "" ]; then
     echo "Running vllm server, please make sure install vllm"
     # Start the first server in the background on port 8000
-    python -m vllm.entrypoints.openai.api_server --served-model-name $MODEL_NAME --model $MODEL_DIR  & SERVER_1_PID=$!
+    python -m vllm.entrypoints.openai.api_server $ALL_ARGS & SERVER_1_PID=$!
     export MODEL_SERVER=vllm-server
     export OPENAI_API_BASE=http://localhost:8000/v1
     echo "Model server: $MODEL_SERVER"
@@ -55,7 +57,7 @@ if [ "$MODEL_DIR" != "" ]; then
     # Function to check if the first server is up
     check_first_server() {
         echo "Checking if Server 1 is up..."
-        for i in {1..1000000000}; do
+        for i in {1..100000000}; do # try up to 100000000 times
             curl -s http://localhost:8000 > /dev/null
             if [ $? -eq 0 ]; then
                 echo "Server 1 is up and running."
@@ -70,9 +72,9 @@ if [ "$MODEL_DIR" != "" ]; then
 
     # Wait for the first server to be up
     if check_first_server; then
-        # Start the second server on port 8001
+        # Start the second server on port 31512
         echo "Starting Server 2..."
-        uvicorn modelscope_agent_servers.assistant_server.api:app --host 0.0.0.0 --port 31512 & $SERVER_2_PID
+        uvicorn modelscope_agent_servers.assistant_server.api:app --host 0.0.0.0 --port 31512 & SERVER_2_PID=$!
     else
         echo "Failed to start Server 1."
         exit 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

When run scripts/run_assistant_server.sh, all the cmd line parameters will be passed to vllm as long as --model is passed. So that parameters of vllm could be passed freely. Someone else could help to extend this idea.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [x] Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
