### PR TITLE
Fix openai usage bug

### DIFF
--- a/modelscope_agent/llm/openai.py
+++ b/modelscope_agent/llm/openai.py
@@ -72,12 +72,17 @@ class OpenAi(BaseChatModel):
             stop=stop,
             stream=False,
             **kwargs)
-        self.stat_last_call_token_info(response)
+        self.stat_last_call_token_info_no_stream(response)
         logger.info(
             f'call openai api success, output: {response.choices[0].message.content}'
         )
         # TODO: error handling
         return response.choices[0].message.content
+
+    def stat_last_call_token_info_no_stream(self, response):
+        if hasattr(response, 'usage'):
+            self.last_call_usage_info = response.usage.dict()
+        return response
 
     def support_function_calling(self):
         if self.is_function_call is None:

--- a/tests/llms/test_vllm.py
+++ b/tests/llms/test_vllm.py
@@ -1,6 +1,7 @@
+from unittest.mock import MagicMock
+
 import pytest
 from modelscope_agent.llm import OpenAi
-from unittest.mock import MagicMock
 
 prompt = 'Tell me a joke.'
 messages = [{
@@ -31,6 +32,7 @@ def chat_model(mocker):
         chat_model, '_chat_no_stream', return_value='hello there')
     return chat_model
 
+
 @pytest.fixture
 def chat_model_usage(mocker):
     """
@@ -45,6 +47,7 @@ def chat_model_usage(mocker):
     chat_model = OpenAi(**llm_config)
     return chat_model
 
+
 def test_chat_stop_word(chat_model):
     stop = chat_model._update_stop_word(['observation'])
     assert isinstance(stop, list)
@@ -56,6 +59,7 @@ def test_chat_stop_word(chat_model):
     assert isinstance(stop, list)
     assert stop == ['<|im_end|>']
 
+
 def test_chat_no_stream_usage_info(chat_model_usage, mocker):
     """
     Test the _chat_no_stream method to ensure it updates the usage info correctly.
@@ -63,11 +67,18 @@ def test_chat_no_stream_usage_info(chat_model_usage, mocker):
     # Mock the OpenAI API response
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = "Test content"
-    mock_response.usage.dict.return_value = {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
+    mock_response.choices[0].message.content = 'Test content'
+    mock_response.usage.dict.return_value = {
+        'prompt_tokens': 5,
+        'completion_tokens': 10,
+        'total_tokens': 15
+    }
 
     # Patch the create method of the client to return the mock response
-    mocker.patch.object(chat_model_usage.client.chat.completions, 'create', return_value=mock_response)
+    mocker.patch.object(
+        chat_model_usage.client.chat.completions,
+        'create',
+        return_value=mock_response)
 
     messages = [{'role': 'user', 'content': 'Hello!'}]
 
@@ -75,7 +86,11 @@ def test_chat_no_stream_usage_info(chat_model_usage, mocker):
     result = chat_model_usage._chat_no_stream(messages)
 
     # Check if the method returns the correct content
-    assert result == "Test content"
+    assert result == 'Test content'
 
     # Check if the usage info is correctly updated
-    assert chat_model_usage.last_call_usage_info == {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
+    assert chat_model_usage.last_call_usage_info == {
+        'prompt_tokens': 5,
+        'completion_tokens': 10,
+        'total_tokens': 15
+    }

--- a/tests/llms/test_vllm.py
+++ b/tests/llms/test_vllm.py
@@ -1,5 +1,6 @@
 import pytest
 from modelscope_agent.llm import OpenAi
+from unittest.mock import MagicMock
 
 prompt = 'Tell me a joke.'
 messages = [{
@@ -30,6 +31,19 @@ def chat_model(mocker):
         chat_model, '_chat_no_stream', return_value='hello there')
     return chat_model
 
+@pytest.fixture
+def chat_model_usage(mocker):
+    """
+    Fixture to create a mock chat model for testing usage info without pre-patching.
+    """
+    llm_config = {
+        'model': 'qwen',
+        'model_server': 'openai',
+        'api_base': 'http://127.0.0.1:8000/v1',
+        'api_key': 'EMPTY'
+    }
+    chat_model = OpenAi(**llm_config)
+    return chat_model
 
 def test_chat_stop_word(chat_model):
     stop = chat_model._update_stop_word(['observation'])
@@ -41,3 +55,27 @@ def test_chat_stop_word(chat_model):
     stop = chat_model._update_stop_word([])
     assert isinstance(stop, list)
     assert stop == ['<|im_end|>']
+
+def test_chat_no_stream_usage_info(chat_model_usage, mocker):
+    """
+    Test the _chat_no_stream method to ensure it updates the usage info correctly.
+    """
+    # Mock the OpenAI API response
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test content"
+    mock_response.usage.dict.return_value = {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
+
+    # Patch the create method of the client to return the mock response
+    mocker.patch.object(chat_model_usage.client.chat.completions, 'create', return_value=mock_response)
+
+    messages = [{'role': 'user', 'content': 'Hello!'}]
+
+    # Call the method
+    result = chat_model_usage._chat_no_stream(messages)
+
+    # Check if the method returns the correct content
+    assert result == "Test content"
+
+    # Check if the usage info is correctly updated
+    assert chat_model_usage.last_call_usage_info == {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}


### PR DESCRIPTION
> ## Change Summary
> ### Problem Description
> When calling the `OpenAi` class's `_chat_no_stream()` method, the `usage_info` result is empty. Upon investigation, the issue was identified in the `stat_last_call_token_info` method. Since this method uses `yield`, it turns into a generator function and does not execute correctly within `_chat_no_stream()`, causing `usage_info` not to be updated properly.
> 
> ### Specific Issue
> When calling the llm with no stream, `usage_info` is empty:
> 
> ```python
> resp = self.llm.chat(messages=msg,
>                      max_tokens=self.max_tokens,
>                      temperature=self.temperature,
>                      stream=False)
> usage_info = self.llm.get_usage()
> ```
> 
> #### Actual Output
> ```
> >>> usage_info = {}
> ```
> 
> #### Expected Output
> ```
> >>> usage_info = {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
> ```
> 
> ## Related issue number
> ## Checklist
> * [x]  The pull request title is a good summary of the changes - it will be used in the changelog
> * [x]  Unit tests for the changes exist
> * [x]  Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
> * [ ]  Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
> * [ ]  Documentation reflects the changes where applicable
> * [x]  My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

