### PR TITLE
Fix bug in `_chat_no_stream` to ensure `last_call_usage_info` is updated correctly

### DIFF
--- a/modelscope_agent/llm/dashscope.py
+++ b/modelscope_agent/llm/dashscope.py
@@ -120,7 +120,7 @@ class DashScopeLLM(BaseChatModel):
             top_p=top_p,
         )
         if response.status_code == HTTPStatus.OK:
-            self.stat_last_call_token_info(response)
+            self.stat_last_call_token_info_no_stream(response)
             return response.output.choices[0].message.content
         else:
             err = 'Error code: %s, error message: %s' % (
@@ -128,6 +128,24 @@ class DashScopeLLM(BaseChatModel):
                 response.message,
             )
             return err
+
+    def stat_last_call_token_info_no_stream(self, response):
+        try:
+            if response.usage is not None:
+                if not response.usage.get('total_tokens'):
+                    total_tokens = response.usage.input_tokens + response.usage.output_tokens
+                else:
+                    total_tokens = response.usage.total_tokens
+                self.last_call_usage_info = {
+                    'prompt_tokens': response.usage.input_tokens,
+                    'completion_tokens': response.usage.output_tokens,
+                    'total_tokens': total_tokens
+                }
+            else:
+                logger.warning('No usage info in response')
+        except AttributeError:
+            logger.warning('No usage info in response')
+        return response
 
     def stat_last_call_token_info(self, response):
         try:

--- a/modelscope_agent/llm/ollama.py
+++ b/modelscope_agent/llm/ollama.py
@@ -55,10 +55,25 @@ class OllamaLLM(BaseChatModel):
             f'call ollama, model: {self.model}, messages: {str(messages)}, '
             f'stop: {str(stop)}, stream: False, args: {str(kwargs)}')
         response = self.client.chat(model=self.model, messages=messages)
-        self.stat_last_call_token_info(response)
+        self.stat_last_call_token_info_no_stream(response)
         final_content = response['message']['content']
         logger.info(f'call ollama success, output: {final_content}')
         return final_content
+
+    def stat_last_call_token_info_no_stream(self, response):
+        try:
+            self.last_call_usage_info = {
+                'prompt_tokens':
+                response.get('prompt_eval_count', -1),
+                'completion_tokens':
+                response.get('eval_count', -1),
+                'total_tokens':
+                response.get('prompt_eval_count') + response.get('eval_count')
+            }
+        except AttributeError:
+            logger.warning('No usage info in response')
+
+        return response
 
     def support_raw_prompt(self) -> bool:
         return super().support_raw_prompt()

--- a/modelscope_agent/llm/openai.py
+++ b/modelscope_agent/llm/openai.py
@@ -72,12 +72,17 @@ class OpenAi(BaseChatModel):
             stop=stop,
             stream=False,
             **kwargs)
-        self.stat_last_call_token_info(response)
+        self.stat_last_call_token_info_no_stream(response)
         logger.info(
             f'call openai api success, output: {response.choices[0].message.content}'
         )
         # TODO: error handling
         return response.choices[0].message.content
+
+    def stat_last_call_token_info_no_stream(self, response):
+        if hasattr(response, 'usage'):
+            self.last_call_usage_info = response.usage.dict()
+        return response
 
     def support_function_calling(self):
         if self.is_function_call is None:

--- a/tests/llms/test_usage_info.py
+++ b/tests/llms/test_usage_info.py
@@ -1,0 +1,147 @@
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import dashscope
+import pytest
+from modelscope_agent.llm import DashScopeLLM, OllamaLLM, OpenAi
+
+
+@pytest.fixture
+def openai_chat_model_usage(mocker):
+    """
+    Fixture to create a mock chat model for testing usage info without pre-patching.
+    """
+    llm_config = {
+        'model': 'qwen',
+        'model_server': 'openai',
+        'api_base': 'http://127.0.0.1:8000/v1',
+        'api_key': 'EMPTY'
+    }
+    chat_model = OpenAi(**llm_config)
+    return chat_model
+
+
+def test_openai_chat_no_stream_usage_info(openai_chat_model_usage, mocker):
+    """
+    Test the _chat_no_stream method to ensure it updates the usage info correctly.
+    """
+    # Mock the OpenAI API response
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = 'Test content'
+    mock_response.usage.dict.return_value = {
+        'prompt_tokens': 5,
+        'completion_tokens': 10,
+        'total_tokens': 15
+    }
+
+    # Patch the create method of the client to return the mock response
+    mocker.patch.object(
+        openai_chat_model_usage.client.chat.completions,
+        'create',
+        return_value=mock_response)
+
+    messages = [{'role': 'user', 'content': 'Hello!'}]
+
+    # Call the method
+    result = openai_chat_model_usage._chat_no_stream(messages)
+
+    # Check if the method returns the correct content
+    assert result == 'Test content'
+
+    # Check if the usage info is correctly updated
+    assert openai_chat_model_usage.last_call_usage_info == {
+        'prompt_tokens': 5,
+        'completion_tokens': 10,
+        'total_tokens': 15
+    }
+
+
+@pytest.fixture
+def dashscope_chat_model(mocker):
+    # using mock llm result as output
+    llm_config = {
+        'model': 'qwen-max',
+        'model_server': 'dashscope',
+        'api_key': 'test'
+    }
+    chat_model = DashScopeLLM(**llm_config)
+    return chat_model
+
+
+def test_dashscope_chat_no_stream_usage_info(dashscope_chat_model, mocker):
+    """
+    Test the _chat_no_stream method to ensure it updates the usage info correctly.
+    """
+    # Mock the OpenAI API response
+    mock_response = MagicMock()
+    mock_response.output.choices = [MagicMock()]
+    mock_response.output.choices[0].message.content = 'Test content'
+    mock_response.usage.input_tokens = 5
+    mock_response.usage.output_tokens = 10
+    mock_response.usage.total_tokens = 15
+
+    mock_response.status_code = HTTPStatus.OK
+
+    # Patch the create method of the client to return the mock response
+    mocker.patch.object(
+        dashscope.Generation, 'call', return_value=mock_response)
+
+    messages = [{'role': 'user', 'content': 'Hello!'}]
+
+    # Call the method
+    result = dashscope_chat_model._chat_no_stream(messages)
+
+    # Check if the method returns the correct content
+    assert result == 'Test content'
+
+    # Check if the usage info is correctly updated
+    assert dashscope_chat_model.last_call_usage_info['prompt_tokens'] == 5
+    assert dashscope_chat_model.last_call_usage_info['completion_tokens'] == 10
+    assert dashscope_chat_model.last_call_usage_info['total_tokens'] == 15
+
+
+@pytest.fixture
+def ollama_chat_model(mocker):
+    # using mock llm result as output
+    llm_config = {
+        'model': 'qwen-max',
+        'model_server': 'ollama',
+        'api_key': 'test'
+    }
+    chat_model = OllamaLLM(**llm_config)
+    return chat_model
+
+
+def test_ollama_chat_no_stream_usage_info(ollama_chat_model, mocker):
+    """
+    Test the _chat_no_stream method to ensure it updates the usage info correctly.
+    """
+    # Mock the OpenAI API response
+    mock_response = MagicMock()
+    mock_response.get.side_effect = lambda key, default=None: {
+        'prompt_eval_count': 5,
+        'eval_count': 10
+    }.get(key, default)
+    mock_response.__getitem__.side_effect = lambda key: {
+        'message': {
+            'content': 'Test content'
+        }
+    }[key]
+    # Patch the create method of the client to return the mock response
+    mocker.patch.object(
+        ollama_chat_model.client, 'chat', return_value=mock_response)
+
+    messages = [{'role': 'user', 'content': 'Hello!'}]
+
+    # Call the method
+    result = ollama_chat_model._chat_no_stream(messages)
+
+    # Check if the method returns the correct content
+    assert result == 'Test content'
+
+    # Check if the usage info is correctly updated
+    assert ollama_chat_model.last_call_usage_info['prompt_tokens'] == 5
+    assert ollama_chat_model.last_call_usage_info['completion_tokens'] == 10
+    assert ollama_chat_model.last_call_usage_info['total_tokens'] == 15


### PR DESCRIPTION
## Change Summary
### Problem Description
When calling the `OpenAi` class's `_chat_no_stream()` method, the `usage_info` result is empty. Upon investigation, the issue was identified in the `stat_last_call_token_info` method. Since this method uses `yield`, it turns into a generator function and does not execute correctly within `_chat_no_stream()`, causing `usage_info` not to be updated properly.

### Specific Issue
When calling the llm with no stream, `usage_info` is empty:

```python
from modelscope_agent.llm import get_chat_model

msg = [ {"role": "user", "content": 'hello'} ]
llm = get_chat_model(**llm_config)
resp = llm.chat(messages=msg,
                max_tokens=1024,
                temperature=1.0,
                stream=False)
usage_info = llm.get_usage()
```
#### Actual Output
```python
>>> usage_info = {}
```
#### Expected Output
```python
>>> usage_info = {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
```

## Related issue number
## Checklist
* [x]  The pull request title is a good summary of the changes - it will be used in the changelog
* [x]  Unit tests for the changes exist
* [x]  Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ]  Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [ ]  Documentation reflects the changes where applicable
* [x]  My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**