### PR TITLE
Fix bug in `_chat_no_stream` to ensure `usage_info` is updated correctly

### DIFF
--- a/modelscope_agent/llm/base.py
+++ b/modelscope_agent/llm/base.py
@@ -287,7 +287,7 @@ class BaseChatModel(ABC):
     def get_usage(self) -> Dict:
         return self.last_call_usage_info
 
-    def stat_last_call_token_info(self, response):
+    def stat_last_call_token_info_stream(self, response):
         try:
             self.last_call_usage_info = response.usage.dict()
             return response
@@ -296,3 +296,8 @@ class BaseChatModel(ABC):
                 if hasattr(chunk, 'usage') and chunk.usage is not None:
                     self.last_call_usage_info = chunk.usage.dict()
                 yield chunk
+
+    def stat_last_call_token_info_no_stream(self, response):
+        if hasattr(response, 'usage'):
+            self.last_call_usage_info = response.usage.dict()
+        return response

--- a/modelscope_agent/llm/ollama.py
+++ b/modelscope_agent/llm/ollama.py
@@ -60,21 +60,6 @@ class OllamaLLM(BaseChatModel):
         logger.info(f'call ollama success, output: {final_content}')
         return final_content
 
-    def stat_last_call_token_info_no_stream(self, response):
-        try:
-            self.last_call_usage_info = {
-                'prompt_tokens':
-                response.get('prompt_eval_count', -1),
-                'completion_tokens':
-                response.get('eval_count', -1),
-                'total_tokens':
-                response.get('prompt_eval_count') + response.get('eval_count')
-            }
-        except AttributeError:
-            logger.warning('No usage info in response')
-
-        return response
-
     def support_raw_prompt(self) -> bool:
         return super().support_raw_prompt()
 
@@ -114,6 +99,21 @@ class OllamaLLM(BaseChatModel):
             messages = [{'role': 'user', 'content': prompt}]
         return super().chat(
             messages=messages, stop=stop, stream=stream, **kwargs)
+
+    def stat_last_call_token_info_no_stream(self, response):
+        try:
+            self.last_call_usage_info = {
+                'prompt_tokens':
+                response.get('prompt_eval_count', -1),
+                'completion_tokens':
+                response.get('eval_count', -1),
+                'total_tokens':
+                response.get('prompt_eval_count') + response.get('eval_count')
+            }
+        except AttributeError:
+            logger.warning('No usage info in response')
+
+        return response
 
     def stat_last_call_token_info_stream(self, response):
         try:

--- a/modelscope_agent/llm/openai.py
+++ b/modelscope_agent/llm/openai.py
@@ -46,7 +46,7 @@ class OpenAi(BaseChatModel):
             stream=True,
             stream_options=stream_options,
             **kwargs)
-        response = self.stat_last_call_token_info(response)
+        response = self.stat_last_call_token_info_stream(response)
         # TODO: error handling
         for chunk in response:
             # sometimes delta.content is None by vllm, we should not yield None
@@ -72,7 +72,7 @@ class OpenAi(BaseChatModel):
             stop=stop,
             stream=False,
             **kwargs)
-        self.stat_last_call_token_info(response)
+        self.stat_last_call_token_info_no_stream(response)
         logger.info(
             f'call openai api success, output: {response.choices[0].message.content}'
         )
@@ -171,7 +171,7 @@ class Vllm(OpenAi):
             f'stop: {str(stop)}, stream: True, args: {str(kwargs)}')
         response = self.client.chat.completions.create(
             model=self.model, messages=messages, stop=stop, stream=True)
-        response = self.stat_last_call_token_info(response)
+        response = self.stat_last_call_token_info_stream(response)
         # TODO: error handling
         for chunk in response:
             # sometimes delta.content is None by vllm, we should not yield None

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -66,7 +66,7 @@ def test_tool_exec_run_state(mocker):
     assert callback.run_states[1][2].name == 'mock_tool'
     assert callback.run_states[1][2].content == '{"test": "test_value"}'
 
-
+@pytest.mark.skipif(IS_FORKED_PR, reason='only run modelscope-agent main repo')
 def test_rag_run_state(mocker):
 
     callback = RunStateCallback()

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -66,6 +66,7 @@ def test_tool_exec_run_state(mocker):
     assert callback.run_states[1][2].name == 'mock_tool'
     assert callback.run_states[1][2].content == '{"test": "test_value"}'
 
+
 @pytest.mark.skipif(IS_FORKED_PR, reason='only run modelscope-agent main repo')
 def test_rag_run_state(mocker):
 


### PR DESCRIPTION
## Change Summary
### Problem Description
When calling the `OpenAi` class's `_chat_no_stream()` method, the `usage_info` result is empty. Upon investigation, the issue was identified in the `stat_last_call_token_info` method. Since this method uses `yield`, it turns into a generator function and does not execute correctly within `_chat_no_stream()`, causing `usage_info` not to be updated properly.

### Specific Issue
When calling the llm with no stream, `usage_info` is empty:

```python
from modelscope_agent.llm import get_chat_model

msg = [ {"role": "user", "content": 'hello'} ]
llm = get_chat_model(**llm_config)
resp = llm.chat(messages=msg,
                max_tokens=1024,
                temperature=1.0,
                stream=False)
usage_info = llm.get_usage()
```
#### Actual Output
```python
>>> usage_info = {}
```
#### Expected Output
```python
>>> usage_info = {'prompt_tokens': 5, 'completion_tokens': 10, 'total_tokens': 15}
```

## Related issue number
## Checklist
* [x]  The pull request title is a good summary of the changes - it will be used in the changelog
* [x]  Unit tests for the changes exist
* [x]  Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ]  Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [ ]  Documentation reflects the changes where applicable
* [x]  My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**