### PR TITLE
Feat: support subfolder for skill_id

### DIFF
--- a/docs/en/Projects/AgentSkills.md
+++ b/docs/en/Projects/AgentSkills.md
@@ -195,6 +195,11 @@ if __name__ == '__main__':
     main()
 ```
 
+- skill_id_or_dir: Path to the local skill directory or skill ID from The ModelScope hub.
+  - skill_id_or_dir (str): e.g. 'path/to/skill-directory', 'ms-agent/skill_examples', 'ma-agent/skill_examples/pdf' (in the form of `owner/skill_name` or `owner/skill_name/subfolder`)
+  - Refer to [AgentSkillExamples](https://modelscope.cn/models/ms-agent/skill_examples) for more details on skill publishing and sharing.
+
+
 
 * Local Execution
   - If `use_sandbox=False`, the skill scripts are executed directly in the local environment

--- a/docs/zh/Projects/智能体技能.md
+++ b/docs/zh/Projects/智能体技能.md
@@ -195,6 +195,11 @@ if __name__ == '__main__':
     main()
 ```
 
+- skill_id_or_dir: 支持传入本地技能目录路径，或从ModelScope Hub加载技能ID。
+  - skill_id_or_dir (str): 示例： 'path/to/skill-directory', 'ms-agent/skill_examples', 'ma-agent/skill_examples/pdf' (格式为 `owner/skill_name` or `owner/skill_name/subfolder`)
+  - 参考 [AgentSkillExamples](https://modelscope.cn/models/ms-agent/skill_examples)
+
+
 * 本地执行
   - 若 `use_sandbox=False`，技能脚本将在本地环境中直接执行
   - 请确保您信任该技能脚本，以避免潜在的安全风险

--- a/ms_agent/agent/agent_skill.py
+++ b/ms_agent/agent/agent_skill.py
@@ -143,7 +143,17 @@ class AgentSkill:
 
             skill_cache_dirs: List[str] = []
             for skill_id in skills:
-                skill_dir: str = snapshot_download(repo_id=skill_id)
+                skill_id_parts: List[str] = skill_id.split('/')
+                subfolder = skill_id_parts[-1] if len(
+                    skill_id_parts) == 3 else None
+                allow_pattern: str = f'{subfolder}/*' if subfolder else None
+                skill_id = '/'.join(
+                    skill_id_parts[:2]) if subfolder else skill_id
+
+                skill_dir: str = snapshot_download(
+                    repo_id=skill_id,
+                    allow_patterns=allow_pattern,
+                )
                 logger.info(
                     f'Downloaded skill from hub: {skill_id} to {skill_dir}')
                 skill_cache_dirs.append(skill_dir)

--- a/ms_agent/utils/utils.py
+++ b/ms_agent/utils/utils.py
@@ -680,7 +680,7 @@ def valid_repo_id(repo_id: str) -> bool:
     Validate the format of a ModelScope repository ID.
 
     Args:
-        repo_id (str): The repository ID to validate. e.g. owner/model_name
+        repo_id (str): The repository ID to validate. e.g. owner/model_name, owner/model_name/subfolder
 
     Returns:
         bool: True if the repo_id is valid, False otherwise.
@@ -689,7 +689,7 @@ def valid_repo_id(repo_id: str) -> bool:
         return False
 
     repo_id_parts: List[str] = repo_id.split('/')
-    if len(repo_id_parts) == 2 and all(repo_id_parts):
+    if len(repo_id_parts) in (2, 3) and all(repo_id_parts):
         return True
 
     return False

--- a/projects/agent_skills/README.md
+++ b/projects/agent_skills/README.md
@@ -83,7 +83,7 @@ def main():
     """
     work_dir: str = str(_PATH / 'temp_workspace')
     # Refer to `https://github.com/modelscope/ms-agent/tree/main/projects/agent_skills/skills`
-    skills_dir: str = str(_PATH / 'skills')
+    skill_id_or_dir: str = str(_PATH / 'skills')
     use_sandbox: bool = True
 
     ## Configuration for ModelScope API-Inference, or set your own model with OpenAI API compatible format
@@ -93,7 +93,7 @@ def main():
     base_url: str = 'https://api-inference.modelscope.cn/v1/'
 
     agent = create_agent_skill(
-        skills=skills_dir,
+        skills=skill_id_or_dir,
         model=model,
         api_key=os.getenv('OPENAI_API_KEY', api_key),
         base_url=os.getenv('OPENAI_BASE_URL', base_url),
@@ -114,6 +114,11 @@ if __name__ == '__main__':
 
     main()
 ```
+
+- skill_id_or_dir: Path to the local skill directory or skill ID from The ModelScope hub.
+  - skill_id_or_dir (str): e.g. 'path/to/skill-directory', 'ms-agent/skill_examples', 'ma-agent/skill_examples/pdf' (in the form of `owner/skill_name` or `owner/skill_name/subfolder`)
+  - Refer to [AgentSkillExamples](https://modelscope.cn/models/ms-agent/skill_examples) for more details on skill publishing and sharing.
+
 
 **Result:**
 


### PR DESCRIPTION
1. In the form of: `owner/skill_name/subfolder`, e.g. `ms-agent/skill_examples/pdf`  (refer to: https://modelscope.cn/models/ms-agent/skill_examples)