### PR TITLE
feat: improve Exa search integration with tracking header and updated API

### DIFF
--- a/ms_agent/tools/search/exa/schema.py
+++ b/ms_agent/tools/search/exa/schema.py
@@ -62,19 +62,15 @@ class ExaSearchRequest:
             'summary': self.summary,
             'type': self.type,
             'num_results': self.num_results,
-            'start_published_date': self.start_published_date,
-            'end_published_date': self.end_published_date,
-            'start_crawl_date': self.start_crawl_date,
-            'end_crawl_date': self.end_crawl_date,
         }
-        if self.include_domains:
-            d['include_domains'] = self.include_domains
-        if self.exclude_domains:
-            d['exclude_domains'] = self.exclude_domains
-        if self.category:
-            d['category'] = self.category
-        if self.user_location:
-            d['user_location'] = self.user_location
+        for field_name in [
+                'start_published_date', 'end_published_date',
+                'start_crawl_date', 'end_crawl_date', 'include_domains',
+                'exclude_domains', 'category', 'user_location',
+        ]:
+            value = getattr(self, field_name)
+            if value:
+                d[field_name] = value
         return d
 
     def to_json(self) -> str:
@@ -108,7 +104,7 @@ class ExaSearchResult:
             print('***Warning: No query provided for search results.')
             return []
 
-        res_list: List[Any] = []
+        res_list: List[Dict[str, Any]] = []
         for res in self.response.results:
             entry: Dict[str, Any] = {
                 'url': getattr(res, 'url', ''),

--- a/ms_agent/tools/search/exa/schema.py
+++ b/ms_agent/tools/search/exa/schema.py
@@ -15,10 +15,17 @@ class ExaSearchRequest:
     # Include text content in the search results or not
     text: Optional[bool] = True
 
-    # Type of search to perform, can be 'auto', 'neural', or 'keyword'
+    # Include highlights in the search results
+    highlights: Optional[bool] = False
+
+    # Include summary in the search results
+    summary: Optional[bool] = False
+
+    # Type of search to perform: 'auto', 'neural', 'fast', 'deep-lite',
+    # 'deep', 'deep-reasoning', or 'instant'
     type: Optional[str] = 'auto'
 
-    # Number of results to return, default is 25
+    # Number of results to return, default is 5
     num_results: Optional[int] = 5
 
     # Date filters for search results, formatted as 'YYYY-MM-DD'
@@ -29,23 +36,46 @@ class ExaSearchRequest:
     start_crawl_date: Optional[str] = None
     end_crawl_date: Optional[str] = None
 
+    # Domain filtering
+    include_domains: Optional[List[str]] = None
+    exclude_domains: Optional[List[str]] = None
+
+    # Category filter: 'company', 'research paper', 'news',
+    # 'personal site', 'financial report', 'people'
+    category: Optional[str] = None
+
+    # User location (two-letter ISO country code)
+    user_location: Optional[str] = None
+
     # temporary field for research goal
     research_goal: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """
-        Convert the request parameters to a dictionary.
+        Convert the request parameters to a dictionary suitable for
+        exa-py's search_and_contents() call.
         """
-        return {
+        d: Dict[str, Any] = {
             'query': self.query,
             'text': self.text,
+            'highlights': self.highlights,
+            'summary': self.summary,
             'type': self.type,
             'num_results': self.num_results,
             'start_published_date': self.start_published_date,
             'end_published_date': self.end_published_date,
             'start_crawl_date': self.start_crawl_date,
-            'end_crawl_date': self.end_crawl_date
+            'end_crawl_date': self.end_crawl_date,
         }
+        if self.include_domains:
+            d['include_domains'] = self.include_domains
+        if self.exclude_domains:
+            d['exclude_domains'] = self.exclude_domains
+        if self.category:
+            d['category'] = self.category
+        if self.user_location:
+            d['user_location'] = self.user_location
+        return d
 
     def to_json(self) -> str:
         """
@@ -64,7 +94,6 @@ class ExaSearchResult:
     arguments: Dict[str, Any] = field(default_factory=dict)
 
     # The response from the Exa search API
-    # SearchResponse(results=[Result(url='https://arxiv.org/abs/2505.02686', id='https://arxiv.org/abs/2505.02686', title='Sailing A...search_type='neural', auto_date=None, cost_dollars=CostDollars(total=0.03, search={'neural': 0.005}, contents={'text': 0.025}))
     response: SearchResponse = None
 
     def to_list(self):
@@ -81,22 +110,28 @@ class ExaSearchResult:
 
         res_list: List[Any] = []
         for res in self.response.results:
-            res_list.append({
-                'url':
-                getattr(res, 'url', ''),
-                'id':
-                getattr(res, 'id', ''),
-                'title':
-                getattr(res, 'title'),
-                'published_date':
-                getattr(res, 'published_date', ''),
-                'summary':
-                getattr(res, 'summary', ''),
-                # 'text': getattr(res, 'text', ''),
-                # 'highlights': getattr(res, 'highlights', ''),
-                # 'highlight_scores': getattr(res, 'highlight_scores', ''),
-                # 'markdown': getattr(res, 'markdown', ''),
-            })
+            entry: Dict[str, Any] = {
+                'url': getattr(res, 'url', ''),
+                'id': getattr(res, 'id', ''),
+                'title': getattr(res, 'title', ''),
+                'published_date': getattr(res, 'published_date', ''),
+            }
+            # Include content fields when available, cascading through
+            # summary > highlights > text for snippet extraction.
+            summary = getattr(res, 'summary', None)
+            highlights = getattr(res, 'highlights', None)
+            text = getattr(res, 'text', None)
+
+            if summary:
+                entry['summary'] = summary
+            if highlights:
+                entry['highlights'] = highlights
+                entry['highlight_scores'] = getattr(
+                    res, 'highlight_scores', None)
+            if text:
+                entry['text'] = text
+
+            res_list.append(entry)
 
         return res_list
 
@@ -104,34 +139,6 @@ class ExaSearchResult:
     def load_from_disk(file_path: str) -> List[Dict[str, Any]]:
         """
         Load search results from a local file.
-
-        Example:
-        [
-            {
-              "query": "Survey of Agent RL in last 3 months",
-              "arguments": {
-                "query": "Survey of Agent RL in last 3 months",
-                "text": true,
-                "type": "auto",
-                "num_results": 25,
-                "start_published_date": "2025-05-01",
-                "end_published_date": "2025-05-29",
-                "start_crawl_date": "2025-01-01",
-                "end_crawl_date": "2025-05-29"
-              },
-              "results": [
-                {
-                  "url": "https://arxiv.org/abs/2505.17342",
-                  "id": "https://arxiv.org/abs/2505.17342",
-                  "title": "A Survey of Safe Reinforcement Learning and Constrained MDPs: A Technical Survey on Single-Agent and Multi-Agent Safety",
-                  "highlights": null,
-                  "highlight_scores": null,
-                  "summary": null,
-                  "markdown": null,
-                },
-                ]
-            },
-        ]
         """
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)

--- a/ms_agent/tools/search/exa/search.py
+++ b/ms_agent/tools/search/exa/search.py
@@ -26,6 +26,7 @@ class ExaSearch(SearchEngine):
         assert api_key, 'EXA_API_KEY must be set either as an argument or as an environment variable'
 
         self.client = Exa(api_key=api_key)
+        self.client.headers['x-exa-integration'] = 'ms-agent'
 
     def search(self, search_request: ExaSearchRequest) -> ExaSearchResult:
         """
@@ -55,10 +56,11 @@ class ExaSearch(SearchEngine):
             tool_name=cls.get_tool_name(),
             server_name=server_name,
             description=(
-                'Search the web using Exa neural search engine. '
+                'Search the web using Exa AI-powered search engine. '
                 'Best for: semantic understanding, finding relevant content, '
                 'recent web pages with date filtering. '
-                'Supports neural search (meaning-based) and keyword search.'),
+                'Supports neural search (meaning-based) and multiple '
+                'search modes including fast, deep, and instant.'),
             parameters={
                 'type': 'object',
                 'properties': {
@@ -67,7 +69,7 @@ class ExaSearch(SearchEngine):
                         'string',
                         'description':
                         ('The search query. For neural search, use natural language '
-                         'descriptions. For keyword search, use Google-style queries.'
+                         'descriptions. For fast search, use Google-style queries.'
                          ),
                     },
                     'num_results': {
@@ -83,11 +85,57 @@ class ExaSearch(SearchEngine):
                     'type': {
                         'type':
                         'string',
-                        'enum': ['auto', 'neural', 'keyword'],
+                        'enum': [
+                            'auto', 'neural', 'fast', 'deep-lite', 'deep',
+                            'deep-reasoning', 'instant'
+                        ],
                         'description':
                         ('Search type. "neural" for semantic similarity, '
-                         '"keyword" for exact matching, "auto" to let Exa decide. '
-                         'Default is "auto".'),
+                         '"fast" for quick results, "deep" for thorough search, '
+                         '"auto" to let Exa decide. Default is "auto".'),
+                    },
+                    'category': {
+                        'type':
+                        'string',
+                        'enum': [
+                            'company', 'research paper', 'news',
+                            'personal site', 'financial report', 'people'
+                        ],
+                        'description':
+                        'Filter results by content category.',
+                    },
+                    'include_domains': {
+                        'type':
+                        'array',
+                        'items': {
+                            'type': 'string'
+                        },
+                        'description':
+                        ('Only return results from these domains '
+                         '(e.g., ["arxiv.org", "github.com"]).'),
+                    },
+                    'exclude_domains': {
+                        'type':
+                        'array',
+                        'items': {
+                            'type': 'string'
+                        },
+                        'description':
+                        'Exclude results from these domains.',
+                    },
+                    'highlights': {
+                        'type':
+                        'boolean',
+                        'description':
+                        ('Return LLM-selected key highlights from each '
+                         'result. Default is false.'),
+                    },
+                    'summary': {
+                        'type':
+                        'boolean',
+                        'description':
+                        ('Return an LLM-generated summary for each '
+                         'result. Default is false.'),
                     },
                     'start_published_date': {
                         'type':
@@ -115,7 +163,13 @@ class ExaSearch(SearchEngine):
             query=kwargs['query'],
             num_results=kwargs.get('num_results', 5),
             type=kwargs.get('type', 'auto'),
-            text=False,
+            text=kwargs.get('text', True),
+            highlights=kwargs.get('highlights', False),
+            summary=kwargs.get('summary', False),
             start_published_date=kwargs.get('start_published_date'),
             end_published_date=kwargs.get('end_published_date'),
+            include_domains=kwargs.get('include_domains'),
+            exclude_domains=kwargs.get('exclude_domains'),
+            category=kwargs.get('category'),
+            user_location=kwargs.get('user_location'),
         )

--- a/tests/search/test_exa_search.py
+++ b/tests/search/test_exa_search.py
@@ -1,0 +1,395 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ms_agent.tools.search.exa.schema import (ExaSearchRequest,
+                                               ExaSearchResult)
+from ms_agent.tools.search.search_base import SearchEngineType
+
+from modelscope.utils.test_utils import test_level
+
+
+class TestExaSearchRequest(unittest.TestCase):
+    """Test cases for ExaSearchRequest class."""
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_init_default_values(self):
+        """Test initialization with default values."""
+        request = ExaSearchRequest(query='AI agents')
+        self.assertEqual(request.query, 'AI agents')
+        self.assertEqual(request.num_results, 5)
+        self.assertEqual(request.type, 'auto')
+        self.assertTrue(request.text)
+        self.assertFalse(request.highlights)
+        self.assertFalse(request.summary)
+        self.assertIsNone(request.category)
+        self.assertIsNone(request.include_domains)
+        self.assertIsNone(request.exclude_domains)
+        self.assertIsNone(request.user_location)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_init_custom_values(self):
+        """Test initialization with custom values."""
+        request = ExaSearchRequest(
+            query='deep learning papers',
+            num_results=10,
+            type='neural',
+            text=True,
+            highlights=True,
+            summary=True,
+            start_published_date='2024-01-01',
+            end_published_date='2024-12-31',
+            include_domains=['arxiv.org'],
+            category='research paper',
+            user_location='US',
+        )
+        self.assertEqual(request.query, 'deep learning papers')
+        self.assertEqual(request.num_results, 10)
+        self.assertEqual(request.type, 'neural')
+        self.assertTrue(request.highlights)
+        self.assertTrue(request.summary)
+        self.assertEqual(request.include_domains, ['arxiv.org'])
+        self.assertEqual(request.category, 'research paper')
+        self.assertEqual(request.user_location, 'US')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_dict_basic(self):
+        """Test conversion to dictionary with defaults."""
+        request = ExaSearchRequest(query='test query')
+        result = request.to_dict()
+        self.assertEqual(result['query'], 'test query')
+        self.assertEqual(result['type'], 'auto')
+        self.assertEqual(result['num_results'], 5)
+        self.assertTrue(result['text'])
+        self.assertFalse(result['highlights'])
+        self.assertFalse(result['summary'])
+        # Optional fields should not be present when None
+        self.assertNotIn('include_domains', result)
+        self.assertNotIn('exclude_domains', result)
+        self.assertNotIn('category', result)
+        self.assertNotIn('user_location', result)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_dict_with_filters(self):
+        """Test conversion to dictionary with domain and category filters."""
+        request = ExaSearchRequest(
+            query='startup funding',
+            include_domains=['techcrunch.com', 'bloomberg.com'],
+            exclude_domains=['reddit.com'],
+            category='news',
+            user_location='US',
+        )
+        result = request.to_dict()
+        self.assertEqual(
+            result['include_domains'], ['techcrunch.com', 'bloomberg.com'])
+        self.assertEqual(result['exclude_domains'], ['reddit.com'])
+        self.assertEqual(result['category'], 'news')
+        self.assertEqual(result['user_location'], 'US')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_json(self):
+        """Test conversion to JSON string."""
+        request = ExaSearchRequest(query='reinforcement learning')
+        json_str = request.to_json()
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed['query'], 'reinforcement learning')
+        self.assertEqual(parsed['type'], 'auto')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_keyword_type_not_default(self):
+        """Verify 'keyword' is not the default search type (it was removed)."""
+        request = ExaSearchRequest(query='test')
+        self.assertNotEqual(request.type, 'keyword')
+
+
+class TestExaSearchResult(unittest.TestCase):
+    """Test cases for ExaSearchResult class."""
+
+    def _make_mock_result(self, **kwargs):
+        """Create a mock result object with the given attributes."""
+        result = MagicMock()
+        defaults = {
+            'url': 'https://example.com',
+            'id': 'https://example.com',
+            'title': 'Test Result',
+            'published_date': '2024-06-15',
+            'summary': None,
+            'highlights': None,
+            'highlight_scores': None,
+            'text': None,
+        }
+        defaults.update(kwargs)
+        for k, v in defaults.items():
+            setattr(result, k, v)
+        return result
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_with_text_only(self):
+        """Test to_list when only text content is present."""
+        mock_response = MagicMock()
+        mock_response.results = [
+            self._make_mock_result(
+                text='Full text content here.',
+            )
+        ]
+        result = ExaSearchResult(
+            query='test', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]['text'], 'Full text content here.')
+        self.assertNotIn('summary', items[0])
+        self.assertNotIn('highlights', items[0])
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_with_highlights(self):
+        """Test to_list when highlights are present."""
+        mock_response = MagicMock()
+        mock_response.results = [
+            self._make_mock_result(
+                highlights=['key point 1', 'key point 2'],
+                highlight_scores=[0.95, 0.88],
+            )
+        ]
+        result = ExaSearchResult(
+            query='test', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(
+            items[0]['highlights'], ['key point 1', 'key point 2'])
+        self.assertEqual(items[0]['highlight_scores'], [0.95, 0.88])
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_with_summary(self):
+        """Test to_list when summary is present."""
+        mock_response = MagicMock()
+        mock_response.results = [
+            self._make_mock_result(
+                summary='A concise summary of the page.',
+            )
+        ]
+        result = ExaSearchResult(
+            query='test', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(
+            items[0]['summary'], 'A concise summary of the page.')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_with_all_content(self):
+        """Test to_list when text, highlights, and summary are all present."""
+        mock_response = MagicMock()
+        mock_response.results = [
+            self._make_mock_result(
+                text='Full text.',
+                highlights=['highlight 1'],
+                highlight_scores=[0.9],
+                summary='Summary text.',
+            )
+        ]
+        result = ExaSearchResult(
+            query='test', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(len(items), 1)
+        self.assertIn('text', items[0])
+        self.assertIn('highlights', items[0])
+        self.assertIn('summary', items[0])
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_with_no_content(self):
+        """Test to_list when no content fields are present."""
+        mock_response = MagicMock()
+        mock_response.results = [
+            self._make_mock_result(
+                url='https://example.com/page',
+                title='Page Title',
+            )
+        ]
+        result = ExaSearchResult(
+            query='test', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]['url'], 'https://example.com/page')
+        self.assertEqual(items[0]['title'], 'Page Title')
+        self.assertNotIn('text', items[0])
+        self.assertNotIn('highlights', items[0])
+        self.assertNotIn('summary', items[0])
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_empty_response(self):
+        """Test to_list with no results."""
+        result = ExaSearchResult(query='test', arguments={}, response=None)
+        items = result.to_list()
+        self.assertEqual(items, [])
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_to_list_empty_query(self):
+        """Test to_list with empty query string."""
+        mock_response = MagicMock()
+        mock_response.results = [self._make_mock_result()]
+        result = ExaSearchResult(
+            query='', arguments={}, response=mock_response)
+        items = result.to_list()
+        self.assertEqual(items, [])
+
+
+class TestExaSearch(unittest.TestCase):
+    """Test cases for ExaSearch class."""
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    @patch.dict(os.environ, {'EXA_API_KEY': 'test-key-123'})
+    @patch('exa_py.Exa')
+    def test_init_sets_integration_header(self, mock_exa_cls):
+        """Test that initialization sets the x-exa-integration header."""
+        mock_client = MagicMock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        from ms_agent.tools.search.exa.search import ExaSearch
+        engine = ExaSearch(api_key='test-key-123')
+        self.assertEqual(engine.engine_type, SearchEngineType.EXA)
+        self.assertEqual(
+            mock_client.headers['x-exa-integration'], 'ms-agent')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_init_requires_api_key(self):
+        """Test that initialization fails without API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove EXA_API_KEY if set
+            os.environ.pop('EXA_API_KEY', None)
+            from ms_agent.tools.search.exa.search import ExaSearch
+            with self.assertRaises(AssertionError):
+                ExaSearch()
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_build_request_from_args_defaults(self):
+        """Test building request with default arguments."""
+        from ms_agent.tools.search.exa.search import ExaSearch
+        request = ExaSearch.build_request_from_args(query='test query')
+        self.assertEqual(request.query, 'test query')
+        self.assertEqual(request.num_results, 5)
+        self.assertEqual(request.type, 'auto')
+        self.assertTrue(request.text)
+        self.assertFalse(request.highlights)
+        self.assertFalse(request.summary)
+        self.assertIsNone(request.include_domains)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_build_request_from_args_full(self):
+        """Test building request with all arguments."""
+        from ms_agent.tools.search.exa.search import ExaSearch
+        request = ExaSearch.build_request_from_args(
+            query='AI news',
+            num_results=10,
+            type='neural',
+            highlights=True,
+            summary=True,
+            category='news',
+            include_domains=['techcrunch.com'],
+            start_published_date='2024-01-01',
+        )
+        self.assertEqual(request.query, 'AI news')
+        self.assertEqual(request.num_results, 10)
+        self.assertEqual(request.type, 'neural')
+        self.assertTrue(request.highlights)
+        self.assertTrue(request.summary)
+        self.assertEqual(request.category, 'news')
+        self.assertEqual(request.include_domains, ['techcrunch.com'])
+        self.assertEqual(request.start_published_date, '2024-01-01')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_tool_definition_no_keyword_type(self):
+        """Verify the tool definition does not include 'keyword' as a type."""
+        from ms_agent.tools.search.exa.search import ExaSearch
+        tool = ExaSearch.get_tool_definition()
+        type_enum = tool.parameters['properties']['type']['enum']
+        self.assertNotIn('keyword', type_enum)
+        self.assertIn('auto', type_enum)
+        self.assertIn('neural', type_enum)
+        self.assertIn('fast', type_enum)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_tool_definition_includes_filtering(self):
+        """Verify the tool definition exposes domain and category filters."""
+        from ms_agent.tools.search.exa.search import ExaSearch
+        tool = ExaSearch.get_tool_definition()
+        props = tool.parameters['properties']
+        self.assertIn('category', props)
+        self.assertIn('include_domains', props)
+        self.assertIn('exclude_domains', props)
+        self.assertIn('highlights', props)
+        self.assertIn('summary', props)
+
+
+class TestExaSearchResultFixture(unittest.TestCase):
+    """Test parsing of a realistic API response fixture."""
+
+    FIXTURE = {
+        'results': [
+            {
+                'id': 'https://arxiv.org/abs/2505.20023',
+                'title': 'Training LLM-Based Agents',
+                'url': 'https://arxiv.org/abs/2505.20023',
+                'publishedDate': '2025-05-26T00:00:00.000Z',
+                'score': 0.367,
+                'text': 'Abstract: Autonomous agents...',
+                'highlights': ['key finding 1', 'key finding 2'],
+                'highlight_scores': [0.95, 0.88],
+                'summary': 'This paper proposes STeP...',
+            },
+            {
+                'id': 'https://arxiv.org/abs/2505.10978',
+                'title': 'Group-in-Group Policy Optimization',
+                'url': 'https://arxiv.org/abs/2505.10978',
+                'publishedDate': '2025-05-16T00:00:00.000Z',
+                'score': 0.366,
+                'text': 'Abstract: Recent advances...',
+                'highlights': None,
+                'highlight_scores': None,
+                'summary': None,
+            },
+        ]
+    }
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_fixture_parsing(self):
+        """Test that a realistic response fixture is parsed correctly."""
+        # Build mock response that mimics exa_py SearchResponse
+        mock_response = MagicMock()
+        mock_results = []
+        for r in self.FIXTURE['results']:
+            mock_result = MagicMock()
+            mock_result.url = r['url']
+            mock_result.id = r['id']
+            mock_result.title = r['title']
+            mock_result.published_date = r['publishedDate']
+            mock_result.text = r.get('text')
+            mock_result.highlights = r.get('highlights')
+            mock_result.highlight_scores = r.get('highlight_scores')
+            mock_result.summary = r.get('summary')
+            mock_results.append(mock_result)
+        mock_response.results = mock_results
+
+        result = ExaSearchResult(
+            query='Agent RL', arguments={}, response=mock_response)
+        items = result.to_list()
+
+        self.assertEqual(len(items), 2)
+
+        # First result has all content fields
+        self.assertEqual(items[0]['title'], 'Training LLM-Based Agents')
+        self.assertEqual(items[0]['text'], 'Abstract: Autonomous agents...')
+        self.assertEqual(
+            items[0]['highlights'], ['key finding 1', 'key finding 2'])
+        self.assertEqual(items[0]['summary'], 'This paper proposes STeP...')
+
+        # Second result has only text (highlights/summary are None)
+        self.assertEqual(
+            items[1]['title'], 'Group-in-Group Policy Optimization')
+        self.assertIn('text', items[1])
+        self.assertNotIn('highlights', items[1])
+        self.assertNotIn('summary', items[1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/search/test_exa_search.py
+++ b/tests/search/test_exa_search.py
@@ -65,6 +65,10 @@ class TestExaSearchRequest(unittest.TestCase):
         self.assertFalse(result['highlights'])
         self.assertFalse(result['summary'])
         # Optional fields should not be present when None
+        self.assertNotIn('start_published_date', result)
+        self.assertNotIn('end_published_date', result)
+        self.assertNotIn('start_crawl_date', result)
+        self.assertNotIn('end_crawl_date', result)
         self.assertNotIn('include_domains', result)
         self.assertNotIn('exclude_domains', result)
         self.assertNotIn('category', result)


### PR DESCRIPTION
## Summary

- **Add `x-exa-integration` tracking header** for API usage attribution (`ms-agent`)
- **Remove deprecated `keyword` search type**; add current types: `fast`, `deep-lite`, `deep`, `deep-reasoning`, `instant`
- **Add content retrieval options**: `highlights` and `summary` alongside existing `text`
- **Add filtering support**: `include_domains`, `exclude_domains`, `category`, `user_location`
- **Fix `to_list()` result formatting** to include text/highlights/summary content fields with graceful fallback when fields are absent
- **Add unit tests** covering schema, search engine initialization, tool definition validation, and response parsing

> **Note on `keyword` search type:** The `keyword` search type has been removed from the Exa API. This PR updates the integration to reflect the current API; agents passing `type="keyword"` should use `type="fast"` instead.

## Usage Example

```python
from ms_agent.tools.search.exa import ExaSearch

engine = ExaSearch()  # uses EXA_API_KEY env var
request = ExaSearch.build_request_from_args(
    query='latest advances in multi-agent systems',
    type='neural',
    num_results=5,
    highlights=True,
    summary=True,
    category='research paper',
    include_domains=['arxiv.org'],
    start_published_date='2024-01-01',
)
result = engine.search(request)
for item in result.to_list():
    print(item['title'], item.get('summary', ''))
```

## Files Changed

- `ms_agent/tools/search/exa/search.py` -- integration header, updated tool definition and request builder
- `ms_agent/tools/search/exa/schema.py` -- new fields (highlights, summary, domain filters, category, user_location), improved `to_list()` with content fallback
- `tests/search/test_exa_search.py` -- new test file with comprehensive coverage

## Test Plan

- [x] `ExaSearchRequest` default values and `to_dict()` serialization
- [x] `ExaSearchRequest` with domain/category/location filters
- [x] `ExaSearchResult.to_list()` with text-only, highlights-only, summary-only, and all-content responses
- [x] `ExaSearchResult.to_list()` graceful fallback when content fields are absent
- [x] `ExaSearchResult.to_list()` with empty response
- [x] `ExaSearch` sets `x-exa-integration: ms-agent` header on initialization
- [x] `ExaSearch` raises `AssertionError` when `EXA_API_KEY` is not set
- [x] `ExaSearch.get_tool_definition()` does not include `keyword` type
- [x] `ExaSearch.get_tool_definition()` exposes all filter parameters
- [x] `ExaSearch.build_request_from_args()` correctly maps all parameters
- [x] Realistic API response fixture parsing